### PR TITLE
use previous state pattern to flip boolean state property

### DIFF
--- a/examples/fancyModal.jsx
+++ b/examples/fancyModal.jsx
@@ -24,7 +24,7 @@ class FancyModalButton extends Component {
   }
 
   toggleModal (e) {
-    this.setState({ isOpen: !this.state.isOpen })
+    this.setState((prevState) => ({ isOpen: !prevState.isOpen }))
   }
 
   render () {

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ class FancyModalButton extends Component {
   }
 
   toggleModal (e) {
-    this.setState({ isOpen: !this.state.isOpen })
+    this.setState((prevState) => ({ isOpen: !prevState.isOpen }))
   }
 
   render () {
@@ -188,7 +188,7 @@ class FancyModalButton extends Component {
   }
 
   toggleModal (e) {
-    this.setState({ isOpen: !this.state.isOpen })
+    this.setState((prevState) => ({ isOpen: !prevState.isOpen }))
   }
 
   render () {


### PR DESCRIPTION
Use previous state pattern to flip boolean state property `isOpen` per React docs https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous