### PR TITLE
Add missing semi colon to BaseModalBackground styles

### DIFF
--- a/src/baseStyles.jsx
+++ b/src/baseStyles.jsx
@@ -10,5 +10,5 @@ export const BaseModalBackground = styled.div`
   z-index: 30;
   background-color: rgba(0, 0, 0, 0.5);
   align-items: center;
-  justify-content: center
+  justify-content: center;
 `


### PR DESCRIPTION
Hello! While using the styled-components v5 beta, I noticed that styled-react-modal was appearing incorrectly. After a little investigation, I found a missing semi-colon in the BaseModalBackground component. It looks like v5 is stricter about missing semi-colons. 

I had a bug in my app where I was extending the baseModalBackground styles, and the short term fix was to actually provide the semi-colon like so:

```
const ModalBackground = styled(BaseModalBackground)`
  ;
  z-index: 1001;
`;
```