### PR TITLE
Dynamic screen-based width and height

### DIFF
--- a/src/baseStyles.jsx
+++ b/src/baseStyles.jsx
@@ -5,8 +5,8 @@ export const BaseModalBackground = styled.div`
   position: fixed;
   top: 0;
   left: 0;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   z-index: 30;
   background-color: rgba(0, 0, 0, 0.5);
   align-items: center;


### PR DESCRIPTION
This `100vh` config is not compatible with Safari mobile - it gets obscured by the dynamic toolbar and nav bar when using viewports as base height https://mobile.twitter.com/simevidas/status/779161023790116865 https://www.eventbrite.com/engineering/mobile-safari-why/

Proposed to change it to base height and width to 100% so that the modal size changes with screen size instead of static viewports.