### PR TITLE
Fixing license metadata to match license file

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "styled-components"
   ],
   "author": "Alexander Richey <alexander.richey@gmail.com>",
-  "license": "UNLICENSED",
+  "license": "Unlicense",
   "bugs": {
     "url": "https://github.com/AlexanderRichey/styled-react-modal/issues"
   },


### PR DESCRIPTION
Hi Alexander,

In package.json files, UNLICENSED means the code is private code rather than under the Unlicense license. Assuming you meant for the latter, I've updated your package.json in this PR.