### PR TITLE
Replaces Modal.defaultProps with default params to align with React 18.3.0's defaultProps deprecation

### DIFF
--- a/src/Modal.jsx
+++ b/src/Modal.jsx
@@ -18,7 +18,7 @@ function Modal({
   afterOpen,
   beforeClose,
   afterClose,
-  backgroundProps,
+  backgroundProps = {},
   isOpen: isOpenProp,
   ...rest
 }) {
@@ -143,10 +143,6 @@ Modal.styled = function (...args) {
   return function (props) {
     return <Modal WrapperComponent={wrap} {...props} />;
   };
-};
-
-Modal.defaultProps = {
-  backgroundProps: {}
 };
 
 Modal.propTypes = {


### PR DESCRIPTION
Proposed solution to issue here: https://github.com/AlexanderRichey/styled-react-modal/issues/71