### PR TITLE
Allow larger ranges of peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   },
   "homepage": "https://github.com/AlexanderRichey/styled-react-modal#readme",
   "peerDependencies": {
-    "react": ">=18",
-    "react-dom": ">=18",
+    "react": ">=18 <19",
+    "react-dom": ">=18 <19",
     "styled-components": ">=6 <7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "react": ">=18",
     "react-dom": ">=18",
-    "styled-components": ">=6"
+    "styled-components": ">=6 <7"
   },
   "devDependencies": {
     "@babel/core": "^7.19.1",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   },
   "homepage": "https://github.com/AlexanderRichey/styled-react-modal#readme",
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
-    "styled-components": "^6.1.1"
+    "react": ">=18",
+    "react-dom": ">=18",
+    "styled-components": ">=6"
   },
   "devDependencies": {
     "@babel/core": "^7.19.1",
@@ -87,5 +87,6 @@
   },
   "dependencies": {
     "prop-types": "^15.8.1"
-  }
+  },
+  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
 }


### PR DESCRIPTION
Allows a larger range on peer dependencies. 

Supports

- React 18
- ReactDOM 18
- styled-components 6

package-manager is added when I use yarn 

> ! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447.
! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager
